### PR TITLE
fix gflags include and only use msgpack-c header files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: cpp
 
 env:
-  - EIGEN_VERSION=3.1.0 EIGEN_HASH=ca142d0540d3 MSGPACK_C_VERSION="0.5.8-patched"
+  - EIGEN_VERSION=3.1.0 EIGEN_HASH=ca142d0540d3 MSGPACK_C_VERSION="1.4.2"
 
 compiler:
   - gcc
@@ -15,9 +15,9 @@ before_install:
   - sudo add-apt-repository -y ppa:boost-latest/ppa
   - if [ "$CXX" == "g++" ]; then sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test; fi
   - sudo apt-get update -yqq
-  - if [ "$CXX" == "g++" ]; then sudo apt-get install -yqq g++-4.7; fi
+  - if [ "$CXX" == "g++" ]; then sudo apt-get install -yqq g++-4.8; fi
   - if [ "$CXX" == "g++" ]; then sudo update-alternatives --install /usr/bin/g++ g++
-    /usr/bin/g++-4.7 50; fi
+    /usr/bin/g++-4.8 50; fi
 
 install:
   - sudo apt-get update -yqq
@@ -36,9 +36,9 @@ install:
     ruby automake libtool
   - cd /tmp
   - wget -O "/tmp/msgpack-c-${MSGPACK_C_VERSION}.tar.gz"
-    "https://github.com/xunzhang/msgpack-c/archive/${MSGPACK_C_VERSION}.tar.gz"
-  - tar -zxvf "/tmp/msgpack-c-${MSGPACK_C_VERSION}.tar.gz" "msgpack-c-${MSGPACK_C_VERSION}"
-  - cd "/tmp/msgpack-c-${MSGPACK_C_VERSION}"
+    "https://github.com/msgpack/msgpack-c/archive/cpp-${MSGPACK_C_VERSION}.tar.gz"
+  - tar -zxvf "/tmp/msgpack-c-${MSGPACK_C_VERSION}.tar.gz" "msgpack-c-cpp-${MSGPACK_C_VERSION}"
+  - cd "/tmp/msgpack-c-cpp-${MSGPACK_C_VERSION}"
   - ./bootstrap
   - ./configure
   - make
@@ -58,6 +58,8 @@ before_script:
   - mkdir build
   - cd build
   - cmake ..
+
+after_failure: "cat /home/travis/build/douban/paracel/build/CMakeFiles/CMakeError.log"
 
 script:
   - make -j2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,13 @@ endif()
 
 include_directories("${PROJECT_SOURCE_DIR}/include")
 ##############################--extern-libraries--##############################
+set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
+find_package(Threads)
+if(CMAKE_USE_PTHREADS_INIT)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
+endif()
+set(CMAKE_LINK_FLAGS ${CMAKE_LINK_FLAGS} ${CMAKE_THREAD_LIBS_INIT})
+
 find_package(MPI REQUIRED)
 include_directories(${MPI_CXX_INCLUDE_PATH})
 set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} ${MPI_CXX_COMPILER_FLAGS})

--- a/alg/classification/logistic_regression/lr_driver.cpp
+++ b/alg/classification/logistic_regression/lr_driver.cpp
@@ -17,7 +17,7 @@
 #include <iostream>
 
 #include <mpi.h>
-#include <google/gflags.h>
+#include <gflags/gflags.h>
 
 #include "lr.hpp"
 #include "utils.hpp"

--- a/alg/clustering/kmeans/kmeans_driver.cpp
+++ b/alg/clustering/kmeans/kmeans_driver.cpp
@@ -16,7 +16,7 @@
 #include <string>
 #include <vector>
 #include <iostream>
-#include <google/gflags.h>
+#include <gflags/gflags.h>
 
 #include "kmeans.hpp"
 //#include "sc.hpp"

--- a/alg/graph_alg/max_vertex_value/max_vertex_value_driver.cpp
+++ b/alg/graph_alg/max_vertex_value/max_vertex_value_driver.cpp
@@ -17,7 +17,7 @@
 #include <iostream>
 
 #include <mpi.h>
-#include <google/gflags.h>
+#include <gflags/gflags.h>
 
 #include "max_vertex_value.hpp"
 #include "utils.hpp"

--- a/alg/graph_alg/max_vertex_value/max_vertex_value_pregel.cpp
+++ b/alg/graph_alg/max_vertex_value/max_vertex_value_pregel.cpp
@@ -15,7 +15,7 @@
 
 #include <string>
 #include <functional>
-#include <google/gflags.h>
+#include <gflags/gflags.h>
 
 #include "ps.hpp"
 #include "pregel.hpp"

--- a/alg/graph_alg/pagerank/main.cpp
+++ b/alg/graph_alg/pagerank/main.cpp
@@ -15,7 +15,7 @@
 
 #include <string>
 #include <iostream>
-#include <google/gflags.h>
+#include <gflags/gflags.h>
 
 #include "pr.hpp"
 #include "utils.hpp"

--- a/alg/misc/word_count/wc_driver.cpp
+++ b/alg/misc/word_count/wc_driver.cpp
@@ -17,7 +17,7 @@
 #include <iostream>
 
 #include <mpi.h>
-#include <google/gflags.h>
+#include <gflags/gflags.h>
 #include <glog/logging.h>
 
 #include "wc.hpp"

--- a/alg/recommendation/adjust_ktop_sparse/driver.cpp
+++ b/alg/recommendation/adjust_ktop_sparse/driver.cpp
@@ -17,7 +17,7 @@
 #include <iostream>
 
 #include <mpi.h>
-#include <google/gflags.h>
+#include <gflags/gflags.h>
 
 #include "adjust_ktop_sparse.hpp"
 #include "utils.hpp"

--- a/alg/recommendation/als/als_driver.cpp
+++ b/alg/recommendation/als/als_driver.cpp
@@ -17,7 +17,7 @@
 #include <iostream>
 
 #include <mpi.h>
-#include <google/gflags.h>
+#include <gflags/gflags.h>
 
 #include "als.hpp"
 #include "utils.hpp"

--- a/alg/recommendation/als/als_validate_driver.cpp
+++ b/alg/recommendation/als/als_validate_driver.cpp
@@ -17,7 +17,7 @@
 #include <iostream>
 
 #include <mpi.h>
-#include <google/gflags.h>
+#include <gflags/gflags.h>
 
 #include "als.hpp"
 #include "utils.hpp"

--- a/alg/recommendation/decision_tree_rec/driver.cpp
+++ b/alg/recommendation/decision_tree_rec/driver.cpp
@@ -15,7 +15,7 @@
 
 #include <string>
 #include <mpi.h>
-#include <google/gflags.h>
+#include <gflags/gflags.h>
 #include "decision_tree_builder.hpp"
 #include "utils.hpp"
 

--- a/alg/recommendation/matrix_factorization/mf_driver.cpp
+++ b/alg/recommendation/matrix_factorization/mf_driver.cpp
@@ -17,7 +17,7 @@
 #include <iostream>
 
 #include <mpi.h>
-#include <google/gflags.h>
+#include <gflags/gflags.h>
 
 #include "mf.hpp"
 #include "utils.hpp"

--- a/alg/recommendation/similarity_dense/ab_driver.cpp
+++ b/alg/recommendation/similarity_dense/ab_driver.cpp
@@ -14,7 +14,7 @@
  */
 
 #include <string>
-#include <google/gflags.h>
+#include <gflags/gflags.h>
 #include "sim_dense.hpp"
 #include "utils.hpp"
 

--- a/alg/recommendation/similarity_dense/driver.cpp
+++ b/alg/recommendation/similarity_dense/driver.cpp
@@ -14,7 +14,7 @@
  */
 
 #include <string>
-#include <google/gflags.h>
+#include <gflags/gflags.h>
 #include "sim_dense.hpp"
 #include "utils.hpp"
 

--- a/alg/recommendation/similarity_sparse/sim_sparse_driver.cpp
+++ b/alg/recommendation/similarity_sparse/sim_sparse_driver.cpp
@@ -14,7 +14,7 @@
  */
 
 #include <string>
-#include <google/gflags.h>
+#include <gflags/gflags.h>
 #include "sim_sparse_row.hpp"
 #include "utils.hpp"
 

--- a/alg/recommendation/svd/main.cpp
+++ b/alg/recommendation/svd/main.cpp
@@ -15,7 +15,7 @@
 
 #include <string>
 #include <iostream>
-#include <google/gflags.h>
+#include <gflags/gflags.h>
 
 #include "svd.hpp"
 #include "utils.hpp"

--- a/alg/regression/ridge/ridge_driver.cpp
+++ b/alg/regression/ridge/ridge_driver.cpp
@@ -17,7 +17,7 @@
 #include <iostream>
 
 #include <mpi.h>
-#include <google/gflags.h>
+#include <gflags/gflags.h>
 
 #include "ridge.hpp"
 #include "utils.hpp"

--- a/alg/topic_model/gLDA_driver.cpp
+++ b/alg/topic_model/gLDA_driver.cpp
@@ -17,7 +17,7 @@
 #include <iostream>
 
 #include <mpi.h>
-#include <google/gflags.h>
+#include <gflags/gflags.h>
 
 #include "gLDA.hpp"
 #include "utils.hpp"

--- a/cmakes/FindGFlags.cmake
+++ b/cmakes/FindGFlags.cmake
@@ -4,7 +4,7 @@
 #  GFlags_INCLUDE_DIR - include to use gflags in paracel
 #  GFlags_LIBRARIES - link to use gflags in paracel
 
-find_path(GFlags_INCLUDE_DIR google/gflags.h
+find_path(GFlags_INCLUDE_DIR gflags/gflags.h
   NO_DEFAULT_PATH
   PATHS
   "/usr/local/include"

--- a/cmakes/FindMsgpackC.cmake
+++ b/cmakes/FindMsgpackC.cmake
@@ -2,7 +2,6 @@
 # - Try to find Msgpack-C
 # Once done, this will be defined:
 #  MsgpackC_INCLUDE_DIR - include to use Msgpack-C in paracel
-#  MsgpackC_LIBRARIES - link to use Message-C in paracel
 
 include(CheckCXXSourceRuns)
 
@@ -12,17 +11,9 @@ find_path(MsgpackC_INCLUDE_DIR msgpack.hpp
   "/usr/local/include"
   "/usr/include")
 
-find_library(MsgpackC_LIBRARY
-  NAMES msgpack libmsgpack
-  HINTS 
-  "/usr/local/lib"
-  "/usr/lib")
-
 message(STATUS "Find Mespack-C include path: ${MsgpackC_INCLUDE_DIR}")
-message(STATUS "Find Mespack-C lib path: ${MsgpackC_LIBRARY}")
 
 set(CMAKE_REQUIRED_INCLUDES ${MsgpackC_INCLUDE_DIR})
-set(CMAKE_REQUIRED_LIBRARIES ${MsgpackC_LIBRARY})
 set(CMAKE_REQUIRED_FLAGS)
 check_cxx_source_runs("
 #include <vector>
@@ -48,12 +39,8 @@ include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(
   MsgpackC
   REQUIRED_VARS
-  MsgpackC_LIBRARY
   MsgpackC_INCLUDE_DIR
   MsgpackC_CHECK_FINE)
 
-set(MsgpackC_LIBRARIES ${MsgpackC_LIBRARY})
-
 mark_as_advanced(
-  MsgpackC_LIBRARIES
   MsgpackC_INCLUDE_DIR)

--- a/doc/index.md
+++ b/doc/index.md
@@ -504,7 +504,7 @@ Since Paracel do not support Eigen::MatrixXd for communication between worker an
 ## Initialize
 
 ```cpp
-#include <google/gflags.h>
+#include <gflags/gflags.h>
 #include "ps.hpp"
 #include "utils.hpp"
 
@@ -559,7 +559,7 @@ Remember
 ## Load
 
 ```cpp
-#include <google/gflags.h>
+#include <gflags/gflags.h>
 #include "ps.hpp"
 #include "utils.hpp"
 #include "graph.hpp"
@@ -764,7 +764,7 @@ Remember
 
 #include <string>
 #include <unordered_map>
-#include <google/gflags.h>
+#include <gflags/gflags.h>
 #include "ps.hpp"
 #include "utils.hpp"
 
@@ -1006,7 +1006,7 @@ Remember
 
 #include <string>
 #include <unordered_map>
-#include <google/gflags.h>
+#include <gflags/gflags.h>
 #include "ps.hpp"
 #include "utils.hpp"
 

--- a/src/paracelrun_cpp_proxy.cpp
+++ b/src/paracelrun_cpp_proxy.cpp
@@ -16,7 +16,7 @@
 #include <string>
 #include <iostream>
 
-#include <google/gflags.h>
+#include <gflags/gflags.h>
 
 #include "utils.hpp"
 

--- a/src/start_server.cpp
+++ b/src/start_server.cpp
@@ -13,7 +13,7 @@
  *
  */
 
-#include <google/gflags.h>
+#include <gflags/gflags.h>
 
 #include "server.hpp"
 

--- a/tool/gLDA_serial.cpp
+++ b/tool/gLDA_serial.cpp
@@ -22,7 +22,7 @@
 #include<vector>
 #include<unordered_map>
 #include<algorithm>
-#include <google/gflags.h>
+#include <gflags/gflags.h>
 #include "ps.hpp"
 #include "utils.hpp"
 

--- a/tool/kmeans_serial.cpp
+++ b/tool/kmeans_serial.cpp
@@ -3,7 +3,7 @@
 #include <algorithm>
 #include <unordered_map>
 
-#include <google/gflags.h>
+#include <gflags/gflags.h>
 
 #include "ps.hpp"
 #include "load.hpp"

--- a/tool/lasso_serial.cpp
+++ b/tool/lasso_serial.cpp
@@ -19,7 +19,7 @@
 #include <vector>
 #include <algorithm>
 #include <iostream>
-#include <google/gflags.h>
+#include <gflags/gflags.h>
 #include "ps.hpp"
 #include "utils.hpp"
 

--- a/tool/lasso_serial_rigid.cpp
+++ b/tool/lasso_serial_rigid.cpp
@@ -19,7 +19,7 @@
 #include <vector>
 #include <algorithm>
 #include <iostream>
-#include <google/gflags.h>
+#include <gflags/gflags.h>
 #include "ps.hpp"
 #include "utils.hpp"
 

--- a/tool/lr_l1_serial.cpp
+++ b/tool/lr_l1_serial.cpp
@@ -19,7 +19,7 @@
 #include <vector>
 #include <algorithm>
 #include <iostream>
-#include <google/gflags.h>
+#include <gflags/gflags.h>
 #include "ps.hpp"
 #include "utils.hpp"
 

--- a/tool/lr_serial.cpp
+++ b/tool/lr_serial.cpp
@@ -21,7 +21,7 @@
 #include <string>
 #include <fstream>
 
-#include <google/gflags.h>
+#include <gflags/gflags.h>
 
 #include "ps.hpp"
 #include "utils.hpp"

--- a/tool/steady_state_inversion_serial.cpp
+++ b/tool/steady_state_inversion_serial.cpp
@@ -19,7 +19,7 @@
 #include <algorithm>
 #include <unordered_map>
 
-#include <google/gflags.h>
+#include <gflags/gflags.h>
 
 #include "ps.hpp"
 #include "load.hpp"

--- a/tool/svd_serial.cpp
+++ b/tool/svd_serial.cpp
@@ -24,7 +24,7 @@
 #include <eigen3/Eigen/Cholesky>
 #include <eigen3/Eigen/SVD>
 
-#include <google/gflags.h>
+#include <gflags/gflags.h>
 
 #include "ps.hpp"
 #include "load.hpp"


### PR DESCRIPTION
`msgpack-c` now is a header only library for C++ program, checking library is not necessary. And `msgpack-c` has already change his library name to `libmsgpackc.so`

cf: https://github.com/msgpack/msgpack-c/blob/cpp-1.4.2/CMakeLists.txt#L260

`gflags` has chaged his namespace to `gflags`