### PR TITLE
[PARACEL-29]. Fix unittest failure under osx.

### DIFF
--- a/test/test_paracel_types.cpp
+++ b/test/test_paracel_types.cpp
@@ -31,15 +31,27 @@ BOOST_AUTO_TEST_CASE (paracel_types_test) {
   PARACEL_CHECK_EQUAL(true, paracel::is_seqic<std::vector<double>>::value);
 
   paracel::hash_type<std::string> hfunc;
+#if (defined __APPLE__)
+  PARACEL_CHECK_EQUAL(hfunc("abcd"), 8979402121050354847UL);
+#else
   PARACEL_CHECK_EQUAL(hfunc("abcd"), 16030370620903852840UL);
-
+#endif
+  
   std::vector<int> tmp2{1, 2, 3};
   paracel::hash_type< std::vector<int> > csfunc;
+#if (defined __APPLE__)
+  PARACEL_CHECK_EQUAL(csfunc(tmp2), 8405338360293734541UL);
+#else
   PARACEL_CHECK_EQUAL(csfunc(tmp2), 15152834183934801446UL);
+#endif
 
   std::vector<char> tmp3{'a', 'b', 'c'};
   paracel::hash_type< std::vector<char> > csfunc2;
+#if (defined __APPLE__)
+  PARACEL_CHECK_EQUAL(csfunc2(tmp3), 12863928803654259868UL);
+#else
   PARACEL_CHECK_EQUAL(csfunc2(tmp3), 1227721600474941649UL);
+#endif
 
   paracel::bag_type<int> bg;
   bg.put(1); bg.put(3); bg.put(5);

--- a/test/test_ring.cpp
+++ b/test/test_ring.cpp
@@ -25,6 +25,62 @@
 #include "utils.hpp"
 #include "test.hpp"
 
+
+
+#if (defined __APPLE__)
+BOOST_AUTO_TEST_CASE (ring_test) {
+  {
+    std::vector<int> server_names{1, 2, 3};
+    paracel::ring<int> ring(server_names);
+    std::string key("dw");
+    PARACEL_CHECK_EQUAL(3, ring.get_server(key));
+    std::string key2("q[,:0]_0");
+    PARACEL_CHECK_EQUAL(2, ring.get_server(key2));
+    std::string key3("q[,:1]_0");
+    PARACEL_CHECK_EQUAL(3, ring.get_server(key3));
+    std::string key4("q[,:2]_0");
+    PARACEL_CHECK_EQUAL(2, ring.get_server(key4));
+    std::string key5("q[,:3]_0");
+    PARACEL_CHECK_EQUAL(2, ring.get_server(key5));
+    std::string key6("p[0:,]_2");
+    PARACEL_CHECK_EQUAL(1, ring.get_server(key6));
+    std::string key7("p[13:,]_2");
+    PARACEL_CHECK_EQUAL(ring.get_server(key7), 2);
+    std::string key8("p[42:,]_2");
+    PARACEL_CHECK_EQUAL(1, ring.get_server(key8));
+    std::string key9("p[5:,]_2");
+    PARACEL_CHECK_EQUAL(3, ring.get_server(key9));
+    std::string key10("p[3:,]_1");
+    PARACEL_CHECK_EQUAL(2, ring.get_server(key10));
+    // char* is unhashable
+    //std::cout << ring.get_server("world") << std::endl;
+  }
+  {
+    std::vector<std::string> server_names{"balin1", "beater5", "beater7"};
+    paracel::ring<std::string> ring(server_names);
+    std::string key("dw");
+    PARACEL_CHECK_EQUAL("balin1", ring.get_server(key));
+    std::string key2("q[,:0]_0");
+    PARACEL_CHECK_EQUAL("beater5", ring.get_server(key2));
+    std::string key3("q[,:1]_0");
+    PARACEL_CHECK_EQUAL("beater7", ring.get_server(key3));
+    std::string key4("q[,:2]_0");
+    PARACEL_CHECK_EQUAL("balin1", ring.get_server(key4));
+    std::string key5("q[,:3]_0");
+    PARACEL_CHECK_EQUAL("beater5", ring.get_server(key5));
+    std::string key6("p[0:,]_2");
+    PARACEL_CHECK_EQUAL("balin1", ring.get_server(key6));
+    std::string key7("p[13:,]_2");
+    PARACEL_CHECK_EQUAL("balin1", ring.get_server(key7));
+    std::string key8("p[42:,]_2");
+    PARACEL_CHECK_EQUAL("balin1", ring.get_server(key8));
+    std::string key9("p[5:,]_2");
+    PARACEL_CHECK_EQUAL("beater7", ring.get_server(key9));
+    std::string key10("p[3:,]_1");
+    PARACEL_CHECK_EQUAL("beater7", ring.get_server(key10));
+  }
+}
+#else
 BOOST_AUTO_TEST_CASE (ring_test) {
   {
     std::vector<int> server_names{1, 2, 3};
@@ -77,3 +133,4 @@ BOOST_AUTO_TEST_CASE (ring_test) {
     PARACEL_CHECK_EQUAL("beater5", ring.get_server(key10));
   }
 }
+#endif

--- a/test/test_utils.cpp
+++ b/test/test_utils.cpp
@@ -104,10 +104,17 @@ BOOST_AUTO_TEST_CASE (utils_hash_test) {
   PARACEL_CHECK_EQUAL(hfunc(d), 3);
   paracel::hash_type<std::string> hfunc2;
   std::string x = "0", y = "1", z = "2", t = "3";
+#if (defined __APPLE__)
+  a = 10408321403207385874ULL;
+  b = 11413460447292444913ULL;
+  c = 17472595041006102391ULL;
+  d = 11275350073939794026ULL;
+#else
   a = 2297668033614959926ULL;
   b = 10159970873491820195ULL;
   c = 4551451650890805270ULL;
   d = 8248777770799913213ULL;
+#endif
   PARACEL_CHECK_EQUAL(hfunc2(x), a);
   PARACEL_CHECK_EQUAL(hfunc2(y), b);
   PARACEL_CHECK_EQUAL(hfunc2(z), c);


### PR DESCRIPTION
Because the std::hash implementation inside clang and gcc is different, we need to fix expected value under osx.